### PR TITLE
Node Documentado

### DIFF
--- a/Main.cpp
+++ b/Main.cpp
@@ -7,7 +7,14 @@
 
 using namespace std;
 
+void syntax_help();
+
 int main(int argc, char const *argv[]) {
+    if (argc == 1) {
+        syntax_help();
+        return 0;
+    }
+
     RegExpr exp;
     stringstream ss(argv[1]);
     ss >> exp;
@@ -45,4 +52,10 @@ int main(int argc, char const *argv[]) {
     }
 
     return 0;
+}
+void syntax_help() {
+    cerr << " Expected regular expression as first parameter" << endl;
+    cerr << " Usage:" << endl;
+    cerr << "\t ./AFTE REGEXPR [OPTION]..." << endl;
+    cerr << "\t ./AFTE REGEXPR [Tree|AFTE_Diagram|AFD_Table|Ignore]..." << endl;
 }

--- a/Source/Node/Node.cpp
+++ b/Source/Node/Node.cpp
@@ -2,16 +2,23 @@
 
 Node::~Node() {}
 
+// height y width se utilizan para posicionar los nodos del diagrama 
+// de transiciones del AFTE.
+// Por defecto N=1 y E=1.
 void Node::initDims() {
     height = N;
     width = 2 * N + E;
 }
 
+// Esta función sirve para iniciar el proceso de recursividad para obtener
+// el codigo Latex del arbol de la expresion. 
 string Node::printTree() {
     int k = 0;
     return printTree(k);
 }
 
+// Función recursiva para obtener el código Latex del arbol de la expresión.
+// Esta definición se utiliza para los nodos 'Empty', 'Lambda' y 'Letter'.
 string Node::printTree(int& k) {
     string s;
     tabs(s, k);
@@ -27,20 +34,22 @@ string Node::printTree(int& k) {
     return s;
 }
 
+// Generar 'k' tabulaciones en la cadena 's'.
 void tabs(string& s, int k) {
     for (int i = 0; i < k; i++) {
         s += '\t';
     }
 }
 
+// Inicializa las dimensiones de los nodos e incia el proceso
+// de recursividad para generar el diagrama de transiciones del AFTE
+// empezando en la coordenada (0.,0.)
 AFTE Node::toAFTE() {
     this->initDims();
     return this->toAFTE(0., 0.);
 }
 
+// Funcion recursiva para generar el código Latex del diagrama de
+// transiciones del AFTE.
 AFTE Node::toAFTE(double x, double y) {
-}
-
-int max(int a, int b) {
-    return a > b ? a : b;
 }

--- a/Source/Node/Node.hpp
+++ b/Source/Node/Node.hpp
@@ -48,6 +48,5 @@ class Node {
 };
 
 void tabs(string& s, int k);
-int max(int a, int b);
 
 #endif /* NODE_HPP */

--- a/make/cpp_project.mk
+++ b/make/cpp_project.mk
@@ -1,5 +1,5 @@
 CXX		:= g++
-TARGET	:= $(PROJNAME)$(EXT)
+TARGET	:= AFTE$(EXT)
 
 HDRS	:= $(shell python make/pyfind.py Source .hpp)
 


### PR DESCRIPTION
Se eliminó una función 'max' en 'Node' que no se utilizaba
Se corrigió el nombre del ejecutable, se generaba con el nombre del directorio en el que se encontraba, ahora es 'AFTE' siempre
Se agregó un mensaje de ayuda cuando se ejecuta el programa sin parámetros